### PR TITLE
TE-1065: Updated symfony/twig-bridge composer constraints. Fixed tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/process": "~2.3|3.0.*",
         "symfony/serializer": "~2.3|3.0.*",
         "symfony/translation": "~2.3|3.0.*",
-        "symfony/twig-bridge": "~2.3|3.0.*",
+        "symfony/twig-bridge": "^3.2.0 || ^4.0.0",
         "symfony/validator": "^3.0.0",
         "twig/twig": "~1.28|~2.0",
         "doctrine/dbal": "~2.2",

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -86,7 +86,7 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit\Framework\MockObject\MockObject
      */
     protected function getMockFormFactory()
     {
@@ -95,6 +95,8 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param \Silex\Application $app
+     *
+     * @return void
      */
     protected function setMockFormFactoryForApplication(Application $app): void
     {

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -26,6 +26,7 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testRegisterAndRender()
     {
         $app = new Application();
+        $this->setMockFormFactoryForApplication($app);
 
         $app->register(new TwigServiceProvider(), array(
             'twig.templates' => array('hello' => 'Hello {{ name }}!'),
@@ -47,6 +48,7 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
         }
 
         $app = new Application();
+        $this->setMockFormFactoryForApplication($app);
 
         $app->register(new HttpFragmentServiceProvider());
         $app->register(new TwigServiceProvider(), array(
@@ -81,5 +83,23 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
             return $loader;
         });
         $this->assertEquals('foo', $app['twig.loader']->getSourceContext('foo')->getCode());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getMockFormFactory()
+    {
+        return $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
+    }
+
+    /**
+     * @param \Silex\Application $app
+     */
+    protected function setMockFormFactoryForApplication(Application $app): void
+    {
+        $app['form.factory'] = function () {
+            return $this->getMockFormFactory();
+        };
     }
 }

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -11,9 +11,11 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use Silex\Application;
 use Silex\Provider\TwigServiceProvider;
 use Silex\Provider\HttpFragmentServiceProvider;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -26,7 +28,7 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testRegisterAndRender()
     {
         $app = new Application();
-        $this->setMockFormFactoryForApplication($app);
+        $app = $this->setMockFormFactoryForApplication($app);
 
         $app->register(new TwigServiceProvider(), array(
             'twig.templates' => array('hello' => 'Hello {{ name }}!'),
@@ -48,7 +50,7 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
         }
 
         $app = new Application();
-        $this->setMockFormFactoryForApplication($app);
+        $app = $this->setMockFormFactoryForApplication($app);
 
         $app->register(new HttpFragmentServiceProvider());
         $app->register(new TwigServiceProvider(), array(
@@ -86,22 +88,14 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject
-     */
-    protected function getMockFormFactory()
-    {
-        return $this->getMockBuilder('Symfony\Component\Form\FormFactoryInterface')->getMock();
-    }
-
-    /**
      * @param \Silex\Application $app
      *
-     * @return void
+     * @return \Silex\Application
      */
-    protected function setMockFormFactoryForApplication(Application $app): void
+    protected function setMockFormFactoryForApplication(Application $app): Application
     {
-        $app['form.factory'] = function () {
-            return $this->getMockFormFactory();
-        };
+        $app['form.factory'] = true;
+
+        return $app;
     }
 }


### PR DESCRIPTION
- Developer(s): @ostrizhny

- Ticket: https://spryker.atlassian.net/browse/TE-1065

- Academy PR: -

- Release Group: https://release.spryker.com/release-groups/view/1116


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Silexphp              | patch (new) {skip}          |                       |

MUST BE RELEASED MANUALLY, not via module releasing.

#### Release Notes

Updated version constraints to `symfony/twig-bridge` to `^3.2.0 || ^4.0.0`, the older versions expect a renderer to be passed to the constructor of the FormExtension.

Additionally, we added a proper test case which also now covers the instantiation of the FormFactory.

-----------------------------------------

#### Module Silexphp

##### Change log

Initial Release

- Updated constraint to `symfony/twig-bridge`.
- Updated `TwigServiceProviderTest` to also cover the instantiation of the `Symfony\Bridge\Twig\Extension\FormExtension`.

