### PR TITLE
TE 1359 removed deprecation warnings which were added to early.

### DIFF
--- a/src/Silex/Provider/ServiceControllerServiceProvider.php
+++ b/src/Silex/Provider/ServiceControllerServiceProvider.php
@@ -15,9 +15,6 @@ use Silex\Application;
 use Silex\ServiceProviderInterface;
 use Silex\ServiceControllerResolver;
 
-/**
- * @deprecated Please add `Spryker\Shared\Application\Service\ControllerResolverServiceProviderPlugin` to your ApplicationDependencyProvider::getServices() to replace this one.
- */
 class ServiceControllerServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -29,8 +29,6 @@ use Twig_Extension_Debug;
 use Twig_Loader_Filesystem;
 
 /**
- * @deprecated Please add `Spryker\Shared\Twig\Service\TwigServiceProvider` to your `ApplicationDependencyProvider::getServices()` to replace this one.
- *
  * Twig integration for Silex.
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Silex/ServiceProviderInterface.php
+++ b/src/Silex/ServiceProviderInterface.php
@@ -12,9 +12,6 @@
 namespace Silex;
 
 /**
- * @deprecated This interface will be removed soon, please check deprecation messages at method level for further
- * information.
- *
  * Interface that all Silex service providers must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
@@ -22,8 +19,6 @@ namespace Silex;
 interface ServiceProviderInterface
 {
     /**
-     * @deprecated Please use `Spryker\Shared\ApplicationExtension\Provider\ServiceInterface::register()` instead.
-     *
      * Registers services on the given app.
      *
      * This method should only be used to configure services and parameters.
@@ -32,9 +27,6 @@ interface ServiceProviderInterface
     public function register(Application $app);
 
     /**
-     * @deprecated Please use `Spryker\Shared\ApplicationExtension\Provider\BootableServiceInterface::boot()` instead if
-     * your service needs to be configured dynamically.
-     *
      * Bootstraps the application.
      *
      * This method is called after all services are registered


### PR DESCRIPTION
Removed to early added deprecations to not confuse projects. We did not refactored all of our code to work without Silex so we need to add the deprecations when we are done with those.