### PR TITLE
TE-966: Create TwigApplicationPlugin

### DIFF
--- a/src/Silex/EventListener/LocaleListener.php
+++ b/src/Silex/EventListener/LocaleListener.php
@@ -18,6 +18,8 @@ use Symfony\Component\HttpKernel\EventListener\LocaleListener as BaseLocaleListe
 use Symfony\Component\Routing\RequestContextAwareInterface;
 
 /**
+ * @deprecated Will be removed without replacement.
+ *
  * Initializes the locale based on the current request.
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -14,7 +14,6 @@ namespace Silex\Provider;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\EventListener\LocaleListener;
-use Silex\LazyUrlMatcher;
 use Silex\Provider\Routing\LazyRequestMatcher;
 use Silex\RedirectableUrlMatcher;
 use Silex\ServiceProviderInterface;
@@ -31,12 +30,19 @@ use Symfony\Component\Routing\RouteCollection;
 class RoutingServiceProvider implements ServiceProviderInterface
 {
     /**
+     * Added for BC reason only.
+     */
+    protected const BC_FEATURE_FLAG_LOCALE_LISTENER = 'BC_FEATURE_FLAG_LOCALE_LISTENER';
+
+    /**
      * @param \Silex\Application $app
      *
      * @return void
      */
     public function register(Application $app)
     {
+        $app[static::BC_FEATURE_FLAG_LOCALE_LISTENER] = true;
+
         $app['route_class'] = 'Silex\\Route';
 
         $app['route_factory'] = function ($app) {
@@ -99,6 +105,8 @@ class RoutingServiceProvider implements ServiceProviderInterface
     {
         $dispatcher = $app['dispatcher'];
         $dispatcher->addSubscriber($app['routing.listener']);
-        $dispatcher->addSubscriber(new LocaleListener($app, $app['url_matcher'], $app['request_stack']));
+        if ($app[static::BC_FEATURE_FLAG_LOCALE_LISTENER]) {
+            $dispatcher->addSubscriber(new LocaleListener($app, $app['url_matcher'], $app['request_stack']));
+        }
     }
 }


### PR DESCRIPTION
- Developer(s): @ostrizhny

- Ticket: https://spryker.atlassian.net/browse/TE-966

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/1267


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Silexphp              | patch        |                       |

#### Release Notes

Silex is abandoned and we had to replace it with our own way of adding ApplicationExtensions to our applications. Previously, we used at least one ServiceProvider to use Twig in our applications. We still need Twig and we need to be able to extend it.

With this release, we provide a BC feature to be able to skip enabling LocaleListener is there is new enabled LocalePlugin.

-----------------------------------------

#### Module Silexphp

##### Change log

Initial Release

* Deprecated `Silex/EventListener/LocaleListener`.
* Added BC feature to use `Silex/EventListener/LocaleListener` if there is no new enabled locale plugin.

