### PR TITLE
TE 1845 migrate psr 0 to psr 4 namespaces

### DIFF
--- a/doc/cookbook/assets.rst
+++ b/doc/cookbook/assets.rst
@@ -50,7 +50,7 @@ If the asset location depends on the asset type or path, you will need more
 abstraction; here is one way to do that with a Twig function::
 
     $app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
-        $twig->addFunction(new \Twig_SimpleFunction('asset', function ($asset) {
+        $twig->addFunction(new \Twig\TwigFunction('asset', function ($asset) {
             // implement whatever logic you need to determine the asset path
 
             return sprintf('http://assets.examples.com/%s', ltrim($asset, '/'));

--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -166,7 +166,7 @@ You can configure the Twig environment before using it by extending the
 
     $app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
         $twig->addGlobal('pi', 3.14);
-        $twig->addFilter('levenshtein', new \Twig\TwigFilter_Function('levenshtein'));
+        $twig->addFilter('levenshtein', new \Twig\TwigFunction('levenshtein'));
 
         return $twig;
     }));

--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -23,7 +23,7 @@ Parameters
 Services
 --------
 
-* **twig**: The ``Twig_Environment`` instance. The main way of
+* **twig**: The ``Environment`` instance. The main way of
   interacting with Twig.
 
 * **twig.loader**: The loader for Twig templates which uses the ``twig.path``
@@ -166,7 +166,7 @@ You can configure the Twig environment before using it by extending the
 
     $app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
         $twig->addGlobal('pi', 3.14);
-        $twig->addFilter('levenshtein', new \Twig_Filter_Function('levenshtein'));
+        $twig->addFilter('levenshtein', new \Twig\TwigFilter_Function('levenshtein'));
 
         return $twig;
     }));

--- a/src/Silex/Provider/Twig/RuntimeLoader.php
+++ b/src/Silex/Provider/Twig/RuntimeLoader.php
@@ -12,13 +12,14 @@
 namespace Silex\Provider\Twig;
 
 use Pimple;
+use Twig\RuntimeLoader\RuntimeLoaderInterface;
 
 /**
  * Loads Twig extension runtimes via Pimple.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class RuntimeLoader implements \Twig\RuntimeLoader\RuntimeLoaderInterface
+class RuntimeLoader implements RuntimeLoaderInterface
 {
     /**
      * @var \Pimple

--- a/src/Silex/Provider/Twig/RuntimeLoader.php
+++ b/src/Silex/Provider/Twig/RuntimeLoader.php
@@ -18,7 +18,7 @@ use Pimple;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class RuntimeLoader implements \Twig_RuntimeLoaderInterface
+class RuntimeLoader implements \Twig\RuntimeLoader\RuntimeLoaderInterface
 {
     /**
      * @var \Pimple

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -26,6 +26,8 @@ use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Component\Form\FormRenderer;
 use Twig\Environment;
 use Twig\Extension\DebugExtension;
+use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -109,11 +111,11 @@ class TwigServiceProvider implements ServiceProviderInterface
         });
 
         $app['twig.loader.array'] = $app->share(function ($app) {
-            return new \Twig\Loader\ArrayLoader($app['twig.templates']);
+            return new ArrayLoader($app['twig.templates']);
         });
 
         $app['twig.loader'] = $app->share(function ($app) {
-            return new \Twig\Loader\ChainLoader(array(
+            return new ChainLoader(array(
                 $app['twig.loader.array'],
                 $app['twig.loader.filesystem'],
             ));

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -24,9 +24,9 @@ use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Component\Form\FormRenderer;
-use Twig_Environment;
-use Twig_Extension_Debug;
-use Twig_Loader_Filesystem;
+use Twig\Environment;
+use AbstractExtension_Debug;
+use Twig\Loader\FilesystemLoader;
 
 /**
  * Twig integration for Silex.
@@ -53,11 +53,11 @@ class TwigServiceProvider implements ServiceProviderInterface
 
             $twigOptions = array_replace($globalOptions, $twigOptions);
 
-            $twig = new Twig_Environment($app['twig.loader'], $twigOptions);
+            $twig = new Environment($app['twig.loader'], $twigOptions);
             $twig->addGlobal('app', $app);
 
             if ($app['debug']) {
-                $twig->addExtension(new Twig_Extension_Debug());
+                $twig->addExtension(new AbstractExtension_Debug());
             }
 
             if (class_exists('Symfony\Bridge\Twig\Extension\RoutingExtension')) {
@@ -93,7 +93,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                     // add loader for Symfony built-in form templates
                     $reflected = new ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
                     $path = dirname($reflected->getFileName()) . '/../Resources/views/Form';
-                    $app['twig.loader']->addLoader(new Twig_Loader_Filesystem($path));
+                    $app['twig.loader']->addLoader(new FilesystemLoader($path));
                 }
             }
 
@@ -105,15 +105,15 @@ class TwigServiceProvider implements ServiceProviderInterface
         });
 
         $app['twig.loader.filesystem'] = $app->share(function ($app) {
-            return new Twig_Loader_Filesystem($app['twig.path']);
+            return new FilesystemLoader($app['twig.path']);
         });
 
         $app['twig.loader.array'] = $app->share(function ($app) {
-            return new \Twig_Loader_Array($app['twig.templates']);
+            return new \Twig\Loader\ArrayLoader($app['twig.templates']);
         });
 
         $app['twig.loader'] = $app->share(function ($app) {
-            return new \Twig_Loader_Chain(array(
+            return new \Twig\Loader\ChainLoader(array(
                 $app['twig.loader.array'],
                 $app['twig.loader.filesystem'],
             ));

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -25,7 +25,7 @@ use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Component\Form\FormRenderer;
 use Twig\Environment;
-use AbstractExtension_Debug;
+use Twig\Extension\DebugExtension;
 use Twig\Loader\FilesystemLoader;
 
 /**
@@ -57,7 +57,7 @@ class TwigServiceProvider implements ServiceProviderInterface
             $twig->addGlobal('app', $app);
 
             if ($app['debug']) {
-                $twig->addExtension(new AbstractExtension_Debug());
+                $twig->addExtension(new DebugExtension());
             }
 
             if (class_exists('Symfony\Bridge\Twig\Extension\RoutingExtension')) {
@@ -76,7 +76,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                 if (isset($app['fragment.handler'])) {
                     $app['fragment.renderer.hinclude']->setTemplating($twig);
 
-                    $twig->addExtension(new HttpKernelExtension($app['fragment.handler']));
+                    $twig->addExtension(new HttpKernelExtension());
                 }
 
                 if (isset($app['form.factory'])) {

--- a/tests/Silex/Tests/Application/TwigTraitTest.php
+++ b/tests/Silex/Tests/Application/TwigTraitTest.php
@@ -28,7 +28,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
         $response = $app->render('view');
@@ -40,7 +40,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
         $response = $app->render('view', array(), new Response('', 404));
@@ -51,7 +51,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('display')->will($this->returnCallback(function () { echo 'foo'; }));
 
         $response = $app->render('view', array(), new StreamedResponse());
@@ -66,7 +66,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render');
 
         $app->renderView('view');

--- a/tests/Silex/Tests/Application/TwigTraitTest.php
+++ b/tests/Silex/Tests/Application/TwigTraitTest.php
@@ -14,6 +14,7 @@ namespace Silex\Tests\Application;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Twig\Environment;
 
 /**
  * TwigTrait test cases.
@@ -28,7 +29,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
         $response = $app->render('view');
@@ -40,7 +41,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
         $response = $app->render('view', array(), new Response('', 404));
@@ -51,7 +52,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('display')->will($this->returnCallback(function () { echo 'foo'; }));
 
         $response = $app->render('view', array(), new StreamedResponse());
@@ -66,7 +67,7 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
     {
         $app = $this->createApplication();
 
-        $app['twig'] = $mailer = $this->getMockBuilder('Environment')->disableOriginalConstructor()->getMock();
+        $app['twig'] = $mailer = $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render');
 
         $app->renderView('view');

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -16,6 +16,7 @@ use Silex\Application;
 use Silex\Provider\HttpFragmentServiceProvider;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
+use Twig\Loader\LoaderInterface;
 
 /**
  * TwigProvider test cases.
@@ -76,7 +77,7 @@ class TwigServiceProviderTest extends PHPUnit_Framework_TestCase
         $app->register(new TwigServiceProvider(), [
             'twig.templates' => ['foo' => 'foo'],
         ]);
-        $loader = $this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock();
+        $loader = $this->getMockBuilder(LoaderInterface::class)->getMock();
         $loader->expects($this->never())->method('getSourceContext');
         $app['twig.loader.filesystem'] = $app->share(function ($app) use ($loader) {
             return $loader;

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -76,7 +76,7 @@ class TwigServiceProviderTest extends PHPUnit_Framework_TestCase
         $app->register(new TwigServiceProvider(), [
             'twig.templates' => ['foo' => 'foo'],
         ]);
-        $loader = $this->getMockBuilder('\Twig_LoaderInterface')->getMock();
+        $loader = $this->getMockBuilder('\Twig\Loader\LoaderInterface')->getMock();
         $loader->expects($this->never())->method('getSourceContext');
         $app['twig.loader.filesystem'] = $app->share(function ($app) use ($loader) {
             return $loader;


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-1845

- Academy PR: ACADEMY_URL_HERE

- Release Overview: https://release.spryker.com/release/package?repo=spryker%2Fsilexphp&branch=bugfix%2Fte-1845-migrate-psr-0-to-psr-4-namespaces&pr=15


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Silexphp              | patch           |                       |

#### Release Notes

Twig added proper class_aliases for all PSR-0 namespaces and we adopted all usages of Twig to make use of the PSR-4 namespace.

-----------------------------------------

#### Module Silexphp

##### Change log

Improvements

- Replaced usage of PSR-0 with PSR-4 namespaces for Twig.

