### PR TITLE
TE-4571 Deprecated Silex.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 The micro framework Silex will no longer be maintained. With this release we introduce a copy of Silex to be able to refactor out Silex and replace it with a Spryker solution. This release will not change any behavior.
 
+**DEPRECATED - This module is not continued at this point.**
 
 ## Installation
 
@@ -13,8 +14,8 @@ The micro framework Silex will no longer be maintained. With this release we int
 composer require spryker/silexphp
 ```
 
-The module `spryker/silex` is now requiring `spryker/silexphp` instead of `silex/silexphp` - as refactored version of it. 
-You do not need to install this manually. Please consider to update `spryker/silex` instead. 
+The module `spryker/silex` is now requiring `spryker/silexphp` instead of `silex/silexphp` - as refactored version of it.
+You do not need to install this manually. Please consider to update `spryker/silex` instead.
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -64,5 +64,6 @@
       "phpstan-setup": "cp composer.json composer.backup && COMPOSER_MEMORY_LIMIT=-1 composer require --dev phpstan/phpstan-shim:^0.11 && mv composer.backup composer.json"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "abandoned": true
 }


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-4571

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Silexphp              | patch (currently 0.x)  |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Silexphp

##### Change log

Initial Release

- Marked module as deprecated.

