### PR TITLE
CC-10037: Upgrade symfony/security in spryker/silexphp.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/routing": "^3.0.0 || ^4.0.0"
     },
     "require-dev": {
-        "symfony/security": "^3.0.0 || ^4.0.0",
+        "symfony/security": "^3.4.26 <4.0.0 || ^4.1.12 <4.2.0 || ^4.2.7 < 4.4.0 || ^4.4.7",
         "symfony/config": "^3.0.0 || ^4.0.0",
         "symfony/intl": "^3.0.0 || ^4.0.0",
         "symfony/form": "^3.0.0 || ^4.0.0",


### PR DESCRIPTION
- Developer(s): @dmiseev 

- Ticket: https://spryker.atlassian.net/browse/CC-10037

- Academy PR: ACADEMY_URL_HERE

- Release Group: URL_HERE


#### Please confirm

- [ ] No new OS components - or they have been approved by legal department

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Silexphp              | patch (currently 0.x)  |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module Silexphp

##### Change log

Initial Release

- Fixed allowed versions for `symfony/security` library to only include safe ones.

