### PR TITLE
TE-10988: Added URI signer secret parameter

### DIFF
--- a/src/Silex/Provider/HttpFragmentServiceProvider.php
+++ b/src/Silex/Provider/HttpFragmentServiceProvider.php
@@ -33,6 +33,13 @@ use Symfony\Component\HttpKernel\UriSigner;
  */
 class HttpFragmentServiceProvider implements ServiceProviderInterface
 {
+    protected $uriSignerSecret;
+
+    public function __construct(?string $uriSignerSecret = null)
+    {
+        $this->uriSignerSecret = $uriSignerSecret ? $uriSignerSecret : md5(__DIR__);
+    }
+
     public function register(Application $app)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
@@ -72,7 +79,7 @@ class HttpFragmentServiceProvider implements ServiceProviderInterface
             return new UriSigner($app['uri_signer.secret']);
         });
 
-        $app['uri_signer.secret'] = md5(__DIR__);
+        $app['uri_signer.secret'] = $this->uriSignerSecret;
         $app['fragment.path'] = '/_fragment';
         $app['fragment.renderer.hinclude.global_template'] = null;
         $app['fragment.renderers'] = $app->share(function ($app) {


### PR DESCRIPTION
- Developer(s): @demkos

- Ticket: https://spryker.atlassian.net/browse/TE-10988


- Release Group: https://release.spryker.com/release-groups/view/4061

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Silexphp              | patch (currently 0.x)  |                       |

-----------------------------------------

#### Module Silexphp

##### Change log

Improvement

- Adjusted `HttpFragmentServiceProvider` to provide ability to set URI Signer secret in constructor instead of using a hash of current directory.

